### PR TITLE
Inserted 'set:html' into title for formatting HTML entities correctly

### DIFF
--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -101,7 +101,7 @@ function validateProps(props) {
 validateProps(props);
 ---
 
-{title ? <title>{title}</title> : null}
+{title ? <title set:html={title}></title> : null}
 
 <link rel="canonical" href={canonical || Astro.request.canonicalURL.href} />
 


### PR DESCRIPTION
Inserted 'set:html' into title for formatting HTML entities correctly. 

Before, the title would leave punctuation unparsed. Example: `"Kyle's website"` would be `"Kyle&apos;s website"`. 

https://docs.astro.build/en/migrate/#deprecated-unescaped-html
