### PR TITLE
Add "seo" keyword to automatically categorize on astro.build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "exports": "./src/index.mjs",
   "keywords": [
     "astro-component"
+    "seo"
   ],
   "author": "Jonas Schumacher",
   "license": "MIT",


### PR DESCRIPTION
https://astro.build/integrations/performance+seo/ is missing `jonasmerlin/astro-seo` despite more npm downloads than other packages. 

Automatic categorization documentation can be found here:

https://docs.astro.build/en/guides/publish-to-npm/#collections