### PR TITLE
Add CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Check code
+        run: npm run check
+      - name: Check formatting
+        run: npm run check:format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,14 @@ jobs:
         run: npm run check
       - name: Check formatting
         run: npm run check:format
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        with:
+          build: npm run build
+          start: npm start

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "cypress:open": "cypress open",
     "dev": "astro dev",
-    "preview": "astro preview",
+    "build": "astro build",
+    "start": "astro preview",
     "format": "prettier -w ./src",
     "check:format": "prettier -c ./src",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "cypress:open": "cypress open",
     "dev": "astro dev",
     "preview": "astro preview",
-    "format": "yarn prettier -w ./src",
+    "format": "prettier -w ./src",
+    "check:format": "prettier -c ./src",
     "release": "standard-version",
     "check": "astro check"
   },

--- a/src/components/OpenGraphArticleTags.astro
+++ b/src/components/OpenGraphArticleTags.astro
@@ -1,5 +1,6 @@
 ---
-const { publishedTime, modifiedTime, expirationTime, authors, section, tags } = Astro.props.openGraph.article;
+const { publishedTime, modifiedTime, expirationTime, authors, section, tags } =
+  Astro.props.openGraph.article;
 ---
 
 {publishedTime ? <meta property="article:published_time" content={publishedTime} /> : null}

--- a/src/components/OpenGraphImageTags.astro
+++ b/src/components/OpenGraphImageTags.astro
@@ -1,6 +1,7 @@
 ---
 const { image } = Astro.props.openGraph.basic;
-const { url, secureUrl, type, width, height, alt } = Astro.props.openGraph.image;
+const { url, secureUrl, type, width, height, alt } =
+  Astro.props.openGraph.image;
 ---
 
 <meta property="og:image:url" content={image} />


### PR DESCRIPTION
## Description

Add CI jobs to run the following:
- `astro check`
- `prettier --check` (and fixed a couple existing violations)
- Cypress tests

[Here](https://github.com/alex-grover/astro-seo/actions/runs/2914658054) is an example of the jobs successfully running and their output, against my fork.

### Possible future work

- Add git hooks to run the linters on commit, if desired
- Automated releases (can you actually release the changes from the earlier PR please?)

