### PR TITLE
Run CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
There was a mistake in the project I copied the CI config from. This correctly runs CI on PR's from all branches.