### PR TITLE
Exporting useful TwitterCardType 

### DIFF
--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -6,7 +6,7 @@ import OpenGraphOptionalTags from "./components/OpenGraphOptionalTags.astro";
 import ExtendedTags from "./components/ExtendedTags.astro";
 import TwitterTags from "./components/TwitterTags.astro";
 
-type TwitterCardType = "summary" | "summary_large_image" | "app" | "player";
+export type TwitterCardType = "summary" | "summary_large_image" | "app" | "player";
 
 export interface Link extends HTMLLinkElement {
   prefetch: boolean;


### PR DESCRIPTION
When passing props to the SEO module the TwitterCardType cannot be imported so you get this error
```
Types of property 'card' are incompatible.
Type 'string' is not assignable to type 'TwitterCardType'
```
exporting the type should enable the correct casting when using the library