### PR TITLE
Add titleDefault and titleTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ import { SEO } from "astro-seo";
 Propname | Type | Description
 ------------ | ------------- | -------------
 title | string | The title of the page.
+titleTemplate | string | Provide a title template to keep a consistent title style. `%s — Astro SEO`, `%s` will be replaced with your title, e.g. `Homepage — Astro SEO`
+titleDefault | string | Fallback title that is used if no title is provided.
 description | string | Text that gives a concise description of what your page is about.
 canonical | string | Prevent duplicate content issues by specifying the "canonical" or "preferred" url of a web page. If you don't define this, `Astro.request.url.href` will be used as the default value.
 noindex | boolean | Set this to true if you don't want search engines to index your page. Since this is an SEO component, this gets set to `false` by default. This way, indexing is strictly opt-out.

--- a/cypress/e2e/seo.cy.js
+++ b/cypress/e2e/seo.cy.js
@@ -9,6 +9,10 @@ describe("Basic Tags", () => {
     cy.title().should("eq", "Francis York Morgan");
   });
 
+  it("default title field is ignored", () => {
+    cy.title().should("not.eq", "Tinker Tailor Soldier Spy");
+  });
+
   it("sets the description", () => {
     cy.get('head meta[name="description"]').should(
       "have.attr",
@@ -417,4 +421,24 @@ describe("Doesn't extend tags", () => {
       "head meta:not([charset], [name='viewport'], [name='description'], [name='robots'])"
     ).should("not.exist");
   });
+});
+
+describe("Default title", () => {
+  beforeEach(() => {
+    cy.visit("localhost:3000/titleDefault");
+  });
+
+  it("default title is used", () => {
+    cy.title().should("eq", "Default Tinker Tailor Soldier Spy");
+  })
+});
+
+describe("Title template", () => {
+  beforeEach(() => {
+    cy.visit("localhost:3000/titleTemplate");
+  });
+
+  it("title template is used", () => {
+    cy.title().should("eq", "Home | Tinker Tailor Soldier Spy");
+  })
 });

--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -19,6 +19,8 @@ export interface Meta extends HTMLMetaElement {
 
 export interface Props {
   title?: string;
+  titleTemplate?: string;
+  titleDefault?: string;
   charset?: string;
   description?: string;
   canonical?: string;
@@ -73,7 +75,7 @@ export interface Props {
 }
 
 const { props } = Astro;
-const { title, description, canonical, noindex, nofollow, charset } = props;
+const { title, titleTemplate, titleDefault, description, canonical, noindex, nofollow, charset } = props;
 
 function validateProps(props) {
   const { openGraph, description } = props;
@@ -107,9 +109,21 @@ function validateProps(props) {
 }
 
 validateProps(props);
+
+let updatedTitle = '';
+
+if (title) {
+  updatedTitle = title;
+  if (titleTemplate) {
+    updatedTitle = titleTemplate.replace(/%s/g, updatedTitle);
+  }
+} else if (titleDefault) {
+  updatedTitle = titleDefault;
+}
+
 ---
 
-{title ? <title set:html={title} /> : null}
+{updatedTitle ? <title set:html={updatedTitle} /> : null}
 
 {charset ? <meta charset={charset} /> : null}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,13 @@
 ---
 import SEO from "../SEO.astro";
 ---
-
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <SEO
       title="Francis York Morgan"
+      titleDefault="Tinker Tailor Soldier Spy"
       description="Agent"
       canonical="Zach"
       charset="utf-8"

--- a/src/pages/titleDefault.astro
+++ b/src/pages/titleDefault.astro
@@ -1,0 +1,16 @@
+---
+import SEO from "../SEO.astro";
+---
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <SEO
+      titleDefault="Default Tinker Tailor Soldier Spy"
+      description="Agent"
+      canonical="Zach"
+      charset="utf-8"
+    />
+  </head>
+  <body>Test</body>
+</html>

--- a/src/pages/titleTemplate.astro
+++ b/src/pages/titleTemplate.astro
@@ -1,0 +1,17 @@
+---
+import SEO from "../SEO.astro";
+---
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <SEO
+      title="Home"
+      titleTemplate="%s | Tinker Tailor Soldier Spy"
+      description="Agent"
+      canonical="Zach"
+      charset="utf-8"
+    />
+  </head>
+  <body>Test</body>
+</html>


### PR DESCRIPTION
Hi there 👋🏻 

This PR adds `titleDefault` and `titleTemplate` fields that mostly match the functionality of its inspiration, `next-seo`. These are two fields that I found myself trying to reach for when using `astro-seo` but realized they weren't available. I saw the line about "feature-parity with Next SEO" mentioned in the README.md, so I figured I'd open a PR for these two fields.

**PR Includes:**
- [x] titleTemplate
- [x] titleDefault
- [x] Tests
- [x] Updated README.md

An example use-case for these fields would be using the `<SEO />` component within a `<Layout>` while getting the page title via props, like so:

```html
<!-- contact.astro -- titleTemplate example, becomes "Contact - Website Name" -->
<Layout title="Contact">
    <!--  [...] page content -->
</Layout>

<!-- about.astro - titleDefault example, forgot to provide a title, fallback to "Website Name - Cool Tagline" -->
<Layout>
   <!-- [...] page content -->
</Layout>

<!-- layout.astro -->
<html lang="en">
   <head>
      <SEO
         charset="UTF-8"
         title={title}
         titleTemplate="%s - Website Name"
         titleDefault="Website Name - Cool Tagline"
      />
   </head>
<!-- [...] -->
```

One minor side note: I went with `titleDefault` instead of `defaultTitle` to keep it consistent with the other title prop names. Another option could be `titleFallback`, or `defaultTitle` would be fine as well.