### PR TITLE
Fixed misprint on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import { SEO } from "astro-seo";
         ],
       }}
     />
+    // ... rest of <head>
   </head>
-  // ... rest of <head>
     <body> // ... body </body>
   </head></html>
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ import { SEO } from "astro-seo";
     // ... rest of <head>
   </head>
     <body> // ... body </body>
-  </head></html>
+  </head>
+</html>
 ```
 
 ## Supported Props


### PR DESCRIPTION
Hello, I have seen that in the example you have in the readme of how to use the <SEO> attribute there was a small error when placing the comments and the closing html tag.
All the best.