### PR TITLE
type & image to openGraph.basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ import { SEO } from "astro-seo";
       openGraph={{
         basic: {
           title: "A Very Descriptive Title"
+          type: "A type.",
+          image: "https://user-images.githubusercontent.com/5182256/131216951-8f74f425-f775-463d-a11b-0e01ad9fce8d.png",
         }
       }}
       twitter={{


### PR DESCRIPTION
Updated the doc to include type & image in openGraph.basic since they're required.