### PR TITLE
Make some properties that can sometimes use the URL constructor accept the URL type

### DIFF
--- a/cypress/e2e/seo.cy.js
+++ b/cypress/e2e/seo.cy.js
@@ -461,3 +461,13 @@ describe("alternate languages", () => {
     cy.get('link[rel=alternate][href="localhost:3000/languageAlternates/fr"]').should('exist')
   })
 });
+
+describe("url as URL object", () => {
+  beforeEach(() => {
+    cy.visit("localhost:3000/urlAsURL");
+  });
+
+  it('checks if canonical is set correctly', function() {
+    cy.get('head link[rel="canonical"]').should("have.attr", "href", "https://github.com/jonasmerlin/astro-seo");
+  })
+});

--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -24,11 +24,11 @@ export interface Props {
   titleDefault?: string;
   charset?: string;
   description?: string;
-  canonical?: string;
+  canonical?: URL | string;
   nofollow?: boolean;
   noindex?: boolean;
   languageAlternates?: {
-    href: string;
+    href: URL | string;
     hrefLang: string;
   }[];
   openGraph?: {
@@ -36,7 +36,7 @@ export interface Props {
       title: string;
       type: string;
       image: string;
-      url?: string;
+      url?: URL | string;
     };
     optional?: {
       audio?: string;
@@ -48,8 +48,8 @@ export interface Props {
       video?: string;
     };
     image?: {
-      url?: string;
-      secureUrl?: string;
+      url?: URL | string;
+      secureUrl?: URL | string;
       type?: string;
       width?: number;
       height?: number;
@@ -70,7 +70,7 @@ export interface Props {
     creator?: string;
     title?: string;
     description?: string;
-    image?: string;
+    image?: URL | string;
     imageAlt?: string;
   };
   extend?: {

--- a/src/pages/urlAsURL.astro
+++ b/src/pages/urlAsURL.astro
@@ -1,0 +1,18 @@
+---
+import SEO from "../SEO.astro";
+
+let url =  new URL("https://github.com/jonasmerlin/astro-seo");
+---
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <SEO
+      title="Francis York Morgan"
+      description="Agent"
+      canonical={url}
+    />
+  </head>
+  <body>Test</body>
+</html>


### PR DESCRIPTION
The component throws an error when I pass a URL type as an argument, this fixes that error so that when creating a URL for social images.

Example:

```astro
---
import { SEO } from "astro-seo";
import aboutImage from "~/assets/images/image.jpg";

const openGraphImage = await getImage({ src: aboutImage, format: "jpeg" });
const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
const socialImageUrl = new URL(openGraphImage.src, Astro.url)
---

<html>
  <head>
    <SEO
      openGraph={{
        // Throws an error because it only accepts string
        image: socialImageUrl,
        url: canonicalUrl
      }}    
    />
  </head>
  <body>
    <!-- Body Content -->
  </body>
</html
```