### PR TITLE
fix: improper use of null when interface asks for undefined

### DIFF
--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -86,9 +86,9 @@ function validateProps(props: Props) {
   if (props.openGraph) {
     if (
       !props.openGraph.basic ||
-      props.openGraph.basic.title == null ||
-      props.openGraph.basic.type == null ||
-      props.openGraph.basic.image == null
+      (props.openGraph.basic.title ?? undefined) == undefined ||
+      (props.openGraph.basic.type ?? undefined) == undefined ||
+      (props.openGraph.basic.image ?? undefined) == undefined
     ) {
       throw new Error(
         "If you pass the openGraph prop, you have to at least define the title, type, and image basic properties!"

--- a/src/components/OpenGraphImageTags.astro
+++ b/src/components/OpenGraphImageTags.astro
@@ -7,9 +7,5 @@ const { secureUrl, type, width, height, alt } = Astro.props.openGraph.image;
 {secureUrl ? <meta property="og:image:secure_url" content={secureUrl} /> : null}
 {type ? <meta property="og:image:type" content={type} /> : null}
 {width ? <meta property="og:image:width" content={width} /> : null}
-{
-  !(height === null) ? (
-    <meta property="og:image:height" content={height} />
-  ) : null
-}
-{!(alt === null) ? <meta property="og:image:alt" content={alt} /> : null}
+{height ? <meta property="og:image:height" content={height} /> : null}
+{alt ? <meta property="og:image:alt" content={alt} /> : null}


### PR DESCRIPTION
`SEO.props` define several properties as being optional with `?`. This extends their accepted types with `undefined`.

However, in multiple places in the code base, an improper check is made that expects the value to be `null`.

In JavaScript and TypeScript, `null` and `undefined` are two completely different values.

This ensures that no matter the value, checks are appropriately made. This was particularly apparent with the generation of invalid `og:image:alt` and `og:image:height` tags if no values were passed to the component.