### PR TITLE
Update typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ title | string | The title of the page.
 titleTemplate | string | Provide a title template to keep a consistent title style. `%s — Astro SEO`, `%s` will be replaced with your title, e.g. `Homepage — Astro SEO`
 titleDefault | string | Fallback title that is used if no title is provided.
 description | string | Text that gives a concise description of what your page is about.
-canonical | string | Prevent duplicate content issues by specifying the "canonical" or "preferred" url of a web page. If you don't define this, `Astro.request.url.href` will be used as the default value.
+canonical | string | Prevent duplicate content issues by specifying the "canonical" or "preferred" url of a web page. If you don't define this, `Astro.url.href` will be used as the default value.
 noindex | boolean | Set this to true if you don't want search engines to index your page. Since this is an SEO component, this gets set to `false` by default. This way, indexing is strictly opt-out.
 nofollow | boolean | Set this to true if you don't want search engines to follow links on your page. Since this is an SEO component, this gets set to `false` by default. This way, following links is strictly opt-out.
 charset | string | Set the charset of the document. In almost all cases this should be UTF-8.


### PR DESCRIPTION
A small typo fix regarding how the default canonical URL is set.

Great package, by the way! I use it on a couple of Astro sites, including my blog ([macarthur.me](https://macarthur.me)) and one of my products ([picperf.dev](https://picperf.dev)). Keep up the great work.  