### PR TITLE
Add support for media attribute on extended meta tags

### DIFF
--- a/src/components/ExtendedTags.astro
+++ b/src/components/ExtendedTags.astro
@@ -8,13 +8,13 @@ type Link = HTMLAttributes<"link">;
 
 {props.extend.link?.map((attributes: Link) => <link {...attributes} />)}
 {
-    props.extend.meta?.map(({ content, httpEquiv, media, name, property }) => (
-        <meta
-            content={content}
-            http-equiv={httpEquiv}
-            media={media}
-            name={name}
-            property={property}
-        />
-    ))
+  props.extend.meta?.map(({ content, httpEquiv, media, name, property }) => (
+    <meta
+      content={content}
+      http-equiv={httpEquiv}
+      media={media}
+      name={name}
+      property={property}
+    />
+  ))
 }

--- a/src/components/ExtendedTags.astro
+++ b/src/components/ExtendedTags.astro
@@ -8,12 +8,13 @@ type Link = HTMLAttributes<"link">;
 
 {props.extend.link?.map((attributes: Link) => <link {...attributes} />)}
 {
-  props.extend.meta?.map(({ content, httpEquiv, name, property }) => (
-    <meta
-      content={content}
-      http-equiv={httpEquiv}
-      name={name}
-      property={property}
-    />
-  ))
+    props.extend.meta?.map(({ content, httpEquiv, media, name, property }) => (
+        <meta
+            content={content}
+            http-equiv={httpEquiv}
+            media={media}
+            name={name}
+            property={property}
+        />
+    ))
 }


### PR DESCRIPTION
The meta element in HTML and HTMLMetaElement support an optional attribute called media, used by HTML theme-color (see https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color). This PR adds the media attribute, if provided, when rendering extended meta tags.

This PR fixes #75.