### PR TITLE
fix(#84): order of properties

### DIFF
--- a/src/components/ExtendedTags.astro
+++ b/src/components/ExtendedTags.astro
@@ -10,11 +10,11 @@ type Link = HTMLAttributes<"link">;
 {
   props.extend.meta?.map(({ content, httpEquiv, media, name, property }) => (
     <meta
+      name={name}
+      property={property}
       content={content}
       http-equiv={httpEquiv}
       media={media}
-      name={name}
-      property={property}
     />
   ))
 }


### PR DESCRIPTION
## Purpose
Right now when using the extended tags functionality, you will see content as the first property rendered. This can make finding tags in the html difficult at a glance.
```
<meta content="Home Page | My Test Site" name="title">
```

We should instead start with either the name or property of the tag to improve readability.

## Testing
- [ ] Confirm that tags are created more like `<meta  name="title" content="Home Page | My Test Site">`
- [ ] Other tag functionality such as OG tags and Twitter tags are unaffected. 
- [ ] Any other build commands are not affected.