### PR TITLE
docs: Fix prop name for article:author

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ openGraph.image.alt | string | Sets `og:image:alt`. A description of what is in 
 openGraph.article.publishedTime | string | Sets `article:published_time`. The date the article was published. Must be a ISO 8601 DateTime string.
 openGraph.article.modifiedTime | string | Sets `article:modified_time`. The date the article was last modified. Must be a ISO 8601 DateTime string.
 openGraph.article.expirationTime | string | Sets `article:expiration_time`. The date the article will no longer be relevant. Must be a ISO 8601 DateTime string.
-openGraph.article.author | string[] | Sets `article:author`. The author(s) of the article, if it's only one, pass an array with one entry. If there are multiple, multiple tags with descending relevance will be created.
+openGraph.article.authors | string[] | Sets `article:author`. The author(s) of the article, if it's only one, pass an array with one entry. If there are multiple, multiple tags with descending relevance will be created.
 openGraph.article.section | string | Sets `article:section`. A high-level section name. E.g. Technology
 openGraph.article.tags | string[] | Sets `article:tag`. Tag words associated with this article. If it's only one, pass an array with one entry. If there are multiple, multiple tags with descending relevance will be created.
 twitter.card | TwitterCardType (string) | Sets `twitter:card`. The card type. Must be one of “summary”, “summary_large_image”, “app”, or “player”.


### PR DESCRIPTION
Prop name is plural.

See https://github.com/jonasmerlin/astro-seo/blob/e03156f1c68917383d6bf2b02526405688a4d58b/src/SEO.astro#L62