### PR TITLE
Make canonical prop optional

### DIFF
--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -25,7 +25,7 @@ export interface Props {
   titleDefault?: string;
   charset?: string;
   description?: string;
-  canonical?: URL | string;
+  canonical?: URL | string | null;
   nofollow?: boolean;
   noindex?: boolean;
   noarchive?: boolean;
@@ -152,7 +152,8 @@ const canonicalHref = shouldRemoveTrailingSlash
 
 {Astro.props.charset ? <meta charset={Astro.props.charset} /> : null}
 
-<link rel="canonical" href={Astro.props.canonical || canonicalHref} />
+{Astro.props.canonical !== null && <link rel="canonical" href={Astro.props.canonical || canonicalHref} />}
+
 
 {
   Astro.props.description ? (

--- a/src/SEO.astro
+++ b/src/SEO.astro
@@ -154,7 +154,6 @@ const canonicalHref = shouldRemoveTrailingSlash
 
 {Astro.props.canonical !== null && <link rel="canonical" href={Astro.props.canonical || canonicalHref} />}
 
-
 {
   Astro.props.description ? (
     <meta name="description" content={Astro.props.description} />


### PR DESCRIPTION
This would fix https://github.com/jonasmerlin/astro-seo/issues/107 

If `canonical` property is not set or is undefined, the canonical will still be set by default as it used to. But if we specifically set `null` as the value of `canonical`, the canonical won't be set